### PR TITLE
Refactoring and coordinate completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 tests/
+fastcov_output.pdf
+*.bam
+*.bam.bai

--- a/custom_logging.py
+++ b/custom_logging.py
@@ -1,0 +1,12 @@
+import sys
+
+
+def error(string, error_type=1):
+    sys.stderr.write(f'ERROR: {string}\n')
+    sys.exit(error_type)
+
+
+def log(string, newline_before=False):
+    if newline_before:
+        sys.stderr.write('\n')
+    sys.stderr.write(f'LOG: {string}\n')

--- a/fastcov.py
+++ b/fastcov.py
@@ -3,78 +3,28 @@
 # SK
 
 import os
-import sys
 import time
-import argparse
 import numpy as np
 import pandas as pd
 import seaborn as sns
 import pysam
 from multiprocessing import Pool
 import matplotlib as mpl
+
+from input_interpretation import parse_args, check_input, parse_or_infer_reference_and_position, BamFileChunk
+from custom_logging import log
+
 mpl.use('Agg') # do not require X window
 from matplotlib import pyplot as plt
 
-#####
-
-def error(string, error_type=1):
-    sys.stderr.write(f'ERROR: {string}\n')
-    sys.exit(error_type)
-
-
-def log(string, newline_before=False):
-    if newline_before:
-        sys.stderr.write('\n')
-    sys.stderr.write(f'LOG: {string}\n')
-
-#####
-
-def worker_get_coverage_ref_name(bamfile, ref_name, pos_start, pos_len):
-
-    log(f'{os.getpid()} working on {bamfile} ...')
-    start_time = time.time()
-    with pysam.AlignmentFile(bamfile, 'rb') as pysam_bamfile:
-
-        # fetch alignments
-        alignments = pysam_bamfile.fetch(ref_name, pos_start, pos_start + pos_len)
-        num_aln = 0
-
-        coverage = np.zeros(pos_len, dtype=int)
-
-        for aln in alignments:
-            num_aln += 1
-            if aln.is_secondary:
-                continue
-
-            # record coverage
-            for pos in aln.positions:
-                pos_shift = pos - pos_start
-                # early stop
-                if pos_shift >= pos_len:
-                    break             
-
-                if 0 <= pos_shift < pos_len:
-                    coverage[pos_shift] += 1
-        
-    log(f'{bamfile}: {num_aln} alignments done in {time.time()-start_time:.2f} sec.')
-
-    return num_aln, coverage
-    
 
 def fastcov_main():
     main_start_time = time.time()
     log('Started fastcov.py ...')
 
-
     ###
     # parse arguments
-    parser = argparse.ArgumentParser(description='Plot the coverage based on some bam files.')
-    parser.add_argument("bamfile", nargs='+', help="Alignment files to include in the coverage plot.")
-    parser.add_argument("-p", "--position", help="Specify a genomic position to plot exclusively. Format: <ref_name>[:<start>-<stop>] (i.e. coordinates are optional and must be 1-based and inclusive)")
-    parser.add_argument("-l", "--logscale", action='store_true', help="Use logarithmic scale on y-axis.")
-    parser.add_argument("-o", "--output_file", help="Specify plot output filename. File extension defines the format (default: fastcov_output.pdf)")
-    parser.add_argument("-c", "--csv_out", help="Specify csv data output filename. Will disable plot output by default, specify --outfile to re-enable plot output.")
-    args = parser.parse_args()
+    args = parse_args()
 
     ###
     # params
@@ -82,79 +32,19 @@ def fastcov_main():
 
     ###
     # input checking
-    bamfiles = args.bamfile
-    num_bamfiles = len(bamfiles)
-    for bamfile in bamfiles:
-        if not os.path.isfile(bamfile):
-            error(f'Not a file: {bamfile}')
-        if not os.path.isfile(bamfile + '.bai'):
-            log(f'Bam index missing for file: {bamfile}. Trying "samtools index {bamfile}" ...')
-            ret = os.system(f'samtools index {bamfile}')
-            if ret != 0:
-                log(f'Warning: samtools index returned exit code {ret} - everything might crash and burn.')
-    log(f'Number of .bam files: {num_bamfiles}')
+    bam_files, num_bam_files = check_input(args)
 
-    # position to get coverage for
-    ref_name = None
-    pos_start = None
-    pos_end = None
+    # position (chunk) to get coverage for
+    with pysam.AlignmentFile(bam_files[0], 'rb') as pysam_bam_file:
+        chunk = parse_or_infer_reference_and_position(args, bam_files, pysam_bam_file)
 
-    with pysam.AlignmentFile(bamfiles[0], 'rb') as pysam_bamfile:
-        # positions are 1-based (inclusive) in this block
-
-        if args.position:
-            if ':' in args.position:
-                # with coords
-                ref_name, startstop_str = args.position.split(':')
-                pos_start_str, pos_end_str = startstop_str.split('-')
-                pos_start = int(pos_start_str)
-                pos_end = int(pos_end_str)
-
-                if pos_start < 1:
-                    error(f'Illegal start position: {pos_start}')
-                if pos_start > pos_end:
-                    error(f'Start position is greater than end position: {pos_start} vs {pos_end}')
-
-            else:
-                # no coords
-                ref_name = args.position
-                log(f'No coordinates given for reference {ref_name}, assuming whole reference. Inferring length from first alignment: {bamfiles[0]}')
-                if ref_name not in pysam_bamfile.references:
-                    error(f'Reference {ref_name} not found in alignment {bamfiles[0]}')
-                # get start/stop
-                pos_start = 1
-                pos_end = pysam_bamfile.lengths[pysam_bamfile.references.index(ref_name)]
-
-        else:
-            # no position
-            log(f'No position given, assuming whole reference. Taking first reference name from first alignment: {bamfiles[0]}')
-            ref_name = pysam_bamfile.references[0]
-            pos_start = 1
-            pos_end = pysam_bamfile.lengths[pysam_bamfile.references.index(ref_name)]
-
-
-    log(f'Position: {ref_name}:{pos_start}-{pos_end} - length: {pos_end-pos_start+1}')
-
-    # convert from 1-based inclusive (genomic) to 0-based half open interval (pythonic)
-    pos_start -= 1
-    pos_len = pos_end - pos_start
-
+    log(f'Position: {chunk.reference}:{chunk.start}-{chunk.end} - length: {chunk.end-chunk.start+1}')
 
     ###
-    # find out how many processes we should use, make worker pool
-    num_cpus = 2
-    max_cpus = os.cpu_count()
-    if not max_cpus:
-        log('Could not determine number of available CPUs, choosing default maximum of 2.')
-    else:
-        if max_cpus > 2:
-            num_cpus = max_cpus
-        if num_bamfiles < num_cpus:
-            num_cpus = num_bamfiles
-        log(f'Using {num_cpus} of {max_cpus} available CPUs.')
+    num_cpus = determine_number_of_cpus_to_use(num_bam_files)
 
     # make a numpy array to hold cov data
-    cov_data = np.zeros([len(bamfiles), pos_len], dtype=int)
+    cov_data = np.zeros([len(bam_files), chunk.length], dtype=int)
     process_results = []
 
     # make worker pool
@@ -163,80 +53,120 @@ def fastcov_main():
     log(f'Made worker pool with {num_cpus} processes.')
     log(f'Parsing alignments ...')
     parse_start_time = time.time()
+    total_num_aln = parse_bam_files(bam_files, chunk, cov_data, pool, process_results)
+    parse_end_time = time.time()
+    parse_time = parse_end_time - parse_start_time
+    log(f'Parsed {total_num_aln} alignments in {parse_time:.2f} seconds')
 
+    # get coverage data into pandas dataframe
+    data = pd.DataFrame(cov_data, index=bam_files, columns=range(chunk.start+1, chunk.end+1)).T
+
+    # data output
+    if args.csv_out:
+        log('Writing csv ...')
+        data.to_csv(args.csv_out)
+        log(f'Wrote csv data to {args.csv_out}')
+        if not args.output_file:
+            do_plots = False
+
+    # plotting
+    if do_plots:
+        log('Plotting ...')
+        output_name = plot(args, chunk, data)
+        log(f'Wrote plot to {output_name}')
+
+    log(f'All done. Took {time.time() - main_start_time:.2f} seconds total. Have a nice day!')
+
+
+def determine_number_of_cpus_to_use(num_bam_files):
+    # find out how many processes we should use, make worker pool
+    num_cpus = 2
+    max_cpus = os.cpu_count()
+    if not max_cpus:
+        log('Could not determine number of available CPUs, choosing default maximum of 2.')
+    else:
+        if max_cpus > 2:
+            num_cpus = max_cpus
+        if num_bam_files < num_cpus:
+            num_cpus = num_bam_files
+        log(f'Using {num_cpus} of {max_cpus} available CPUs.')
+    return num_cpus
+
+
+def parse_bam_files(bam_files, chunk, cov_data, pool, process_results):
     # send work to pool
-    for bamfile in bamfiles:
-        res = pool.apply_async(worker_get_coverage_ref_name, (bamfile, ref_name, pos_start, pos_len))
+    for bam_file in bam_files:
+        res = pool.apply_async(worker_get_coverage_ref_name, (bam_file, chunk))
         process_results.append(res)
-
     # wait for results
     total_num_aln = 0
     for i, res in enumerate(process_results):
         # write to array
         num_aln, cov_data[i] = res.get()
         total_num_aln += num_aln
-
-    parse_end_time = time.time()
-    parse_time = parse_end_time - parse_start_time
-    log(f'Parsed {total_num_aln} alignments in {parse_time:.2f} seconds')
+    return total_num_aln
 
 
-    # get coverage data into pandas dataframe
-    data = pd.DataFrame(cov_data, index=bamfiles, columns=range(pos_start+1, pos_end+1)).T
+def worker_get_coverage_ref_name(bam_file: str, chunk: BamFileChunk):
+
+    log(f'{os.getpid()} working on {bam_file} ...')
+    start_time = time.time()
+    with pysam.AlignmentFile(bam_file, 'rb') as pysam_bamfile:
+
+        # fetch alignments
+        alignments = pysam_bamfile.fetch(chunk.reference, chunk.start, chunk.start+chunk.length)
+        num_aln = 0
+
+        coverage = np.zeros(chunk.length, dtype=int)
+
+        for aln in alignments:
+            num_aln += 1
+            if aln.is_secondary:
+                continue
+
+            # record coverage
+            for pos in aln.positions:
+                pos_shift = pos - chunk.start
+                # early stop
+                if pos_shift >= chunk.length:
+                    break
+
+                if 0 <= pos_shift < chunk.length:
+                    coverage[pos_shift] += 1
+
+    log(f'{bam_file}: {num_aln} alignments done in {time.time() - start_time:.2f} sec.')
+
+    return num_aln, coverage
 
 
-    ###
-    # data output
-    if args.csv_out:
-        data.to_csv(args.csv_out)
-        log(f'Wrote csv data to {args.csv_out}')
-        if not args.output_file:
-            do_plots = False
-
-
-    ###
-    # plotting
-    if do_plots:
-
-        log('Plotting ...')
-        output_name = 'fastcov_output.pdf'
-        if args.output_file:
-            output_name = args.output_file
-
-
-        # plot it
-        sns.set(style="whitegrid")
-        fig, ax = plt.subplots(figsize=(20, 9))
-
-        p = sns.lineplot(data=data, linewidth=1.5, dashes=False, alpha=0.8)
-
-
-        # formatting and annotation
-        ydn, yup = plt.ylim()
-        if args.logscale:
-            data_max = data.max().max()
-            next_pow_10 = 10
-            while next_pow_10 <= data_max:
-                next_pow_10 *= 10
-            plt.ylim(0.5, next_pow_10*2)
-            plt.yscale('log')
-        else:
-            plt.ylim(-yup/40, yup+(yup/40))
-
-        plt.vlines([pos_start+.5, pos_end+.5], *plt.ylim(), 'grey', linestyles='dashed', linewidth=.5)
-        plt.title(f'Coverage at {ref_name}:{pos_start+1}-{pos_end}')
-        plt.ylabel('coverage')
-        plt.xlabel('reference position')
-
-        plt.text(0.045, 0.065, str(pos_start+1), rotation=90, ha='right', va='bottom', transform=ax.transAxes)
-        plt.text(0.956, 0.065, str(pos_end), rotation=90, ha='left', va='bottom', transform=ax.transAxes)
-
-
-        # save figure
-        plt.savefig(output_name, bbox_inches='tight')
-        log(f'Wrote plot to {output_name}')
-
-    log(f'All done. Took {time.time() - main_start_time:.2f} seconds total. Have a nice day!')
+def plot(args, chunk, data) -> str:
+    output_name = 'fastcov_output.pdf'
+    if args.output_file:
+        output_name = args.output_file
+    # plot it
+    sns.set(style="whitegrid")
+    fig, ax = plt.subplots(figsize=(20, 9))
+    p = sns.lineplot(data=data, linewidth=1.5, dashes=False, alpha=0.8)
+    # formatting and annotation
+    ydn, yup = plt.ylim()
+    if args.logscale:
+        data_max = data.max().max()
+        next_pow_10 = 10
+        while next_pow_10 <= data_max:
+            next_pow_10 *= 10
+        plt.ylim(0.5, next_pow_10 * 2)
+        plt.yscale('log')
+    else:
+        plt.ylim(-yup / 40, yup + (yup / 40))
+    plt.vlines([chunk.start + .5, chunk.end + .5], *plt.ylim(), 'grey', linestyles='dashed', linewidth=.5)
+    plt.title(f'Coverage at {chunk.reference}:{chunk.start + 1}-{chunk.end}')
+    plt.ylabel('coverage')
+    plt.xlabel('reference position')
+    plt.text(0.045, 0.065, str(chunk.start + 1), rotation=90, ha='right', va='bottom', transform=ax.transAxes)
+    plt.text(0.956, 0.065, str(chunk.end), rotation=90, ha='left', va='bottom', transform=ax.transAxes)
+    # save figure
+    plt.savefig(output_name, bbox_inches='tight')
+    return output_name
 
 
 if __name__ == '__main__':

--- a/input_interpretation.py
+++ b/input_interpretation.py
@@ -1,0 +1,100 @@
+import argparse
+import os
+from typing import NamedTuple
+from custom_logging import error, log
+
+
+class BamFileChunk(NamedTuple):
+    reference: str
+    start: int
+    end: int
+    length: int
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Plot the coverage based on some bam files.')
+    parser.add_argument("bamfile",
+                        nargs='+',
+                        help="Alignment files to include in the coverage plot.")
+    parser.add_argument("-p", "--position",
+                        help="Specify a genomic position to plot exclusively. Format: <ref_name>[:<start>-<stop>] "
+                             "(i.e. coordinates are optional and must be 1-based and inclusive)")
+    parser.add_argument("-l", "--logscale", action='store_true',
+                        help="Use logarithmic scale on y-axis.")
+    parser.add_argument("-o", "--output_file",
+                        help="Specify plot output filename. File extension defines the format "
+                             "(default: fastcov_output.pdf)")
+    parser.add_argument("-c", "--csv_out",
+                        help="Specify csv data output filename. Will disable plot output by default, "
+                             "specify --outfile to re-enable plot output.")
+    args = parser.parse_args()
+    return args
+
+
+def check_input(args):
+    bam_files = args.bamfile
+    num_bam_files = len(bam_files)
+    for bam_file in bam_files:
+        if not os.path.isfile(bam_file):
+            error(f'Not a file: {bam_file}')
+        if not os.path.isfile(bam_file + '.bai'):
+            log(f'Bam index missing for file: {bam_file}. Trying "samtools index {bam_file}" ...')
+            ret = os.system(f'samtools index {bam_file}')
+            if ret != 0:
+                log(f'Warning: samtools index returned exit code {ret} - everything might crash and burn.')
+    log(f'Number of .bam files: {num_bam_files}')
+    return bam_files, num_bam_files
+
+
+def parse_or_infer_reference_and_position(args, bam_files, pysam_bam_file) -> BamFileChunk:
+    # positions are 1-based (inclusive) in this block
+    if args.position:
+        if ':' in args.position:
+            # with coords
+            ref_name, start_stop_str = args.position.split(':')
+            if '-' not in start_stop_str:
+                error('Please provide a start and/or stop position. '
+                      'When providing only a start or stop position, '
+                      'indicate the intervals side to use by pre- or postfixing the value with "-" '
+                      '(e.g. "100-" or "-200"). '
+                      'The other side will be inferred from the given reference')
+            pos_start_str, pos_end_str = start_stop_str.split('-')
+            pos_start = convert_to_int_or_fallback(pos_start_str,
+                                                   fallback=1)
+            pos_end = convert_to_int_or_fallback(pos_end_str,
+                                                 fallback=pysam_bam_file.lengths[pysam_bam_file.references.index(ref_name)])
+
+            if pos_start < 1:
+                error(f'Illegal start position: {pos_start}')
+            if pos_start > pos_end:
+                error(f'Start position is greater than end position: {pos_start} vs {pos_end}')
+
+        else:
+            # no coords
+            ref_name = args.position
+            log(f'No coordinates given for reference {ref_name}, assuming whole reference. '
+                f'Inferring length from first alignment: {bam_files[0]}')
+            if ref_name not in pysam_bam_file.references:
+                error(f'Reference {ref_name} not found in alignment {bam_files[0]}')
+            # get start/stop
+            pos_start = 1
+            pos_end = pysam_bam_file.lengths[pysam_bam_file.references.index(ref_name)]
+    else:
+        # no position
+        log(
+            f'No position given, assuming whole reference. Taking first reference name from first alignment: {bam_files[0]}')
+        ref_name = pysam_bam_file.references[0]
+        pos_start = 1
+        pos_end = pysam_bam_file.lengths[pysam_bam_file.references.index(ref_name)]
+
+    # convert from 1-based inclusive (genomic) to 0-based half open interval (pythonic)
+    pos_start -= 1
+    pos_len = pos_end - pos_start
+    return BamFileChunk(end=pos_end, start=pos_start, reference=ref_name, length=pos_len)
+
+
+def convert_to_int_or_fallback(string: str, fallback: int):
+    try:
+        return int(string)
+    except ValueError:
+        return fallback


### PR DESCRIPTION
* Introduces `BamFileChunk`, a data container for storing the section (reference and coordinates) to be parsed within a bamfile
* Extracts input parsing into own module (separation of concerns)
* Extracts logging into own module (separation of concerns)
* Chops up `fastcov_main` into functions (replaces strings describing the sections purpose with function names - which are more likely to be refactored than strings)
* fastcov now allows to provide either the start or end coordinate exclusively by using the provided references max coordinate (when only a start pos is given) or 1 (if only a stop pos is given).
  Example: `$ python fastcov.py bamfile.bam -p chr1:-1000` or `$ python fastcov.py bamfile.bam -p chr1:1337-`